### PR TITLE
debug-connectivity: common errors and https path validation

### DIFF
--- a/aws-privatelink/debug-connectivity.sh
+++ b/aws-privatelink/debug-connectivity.sh
@@ -44,7 +44,7 @@ fi
 endpoint=$1
 bootstrap=$2
 key=$3
-#           lkc-py7g5-4ny6k.us-west-2.aws.glb.confluent.cloud
+#           lkc-py7g5-4ny6k.us-west-2.aws.glb.confluent.cloud:9092
 # yields              4ny6k.us-west-2.aws.confluent.cloud
 hz=$(echo "$bootstrap" | sed -E -e 's/^[^-]*-[^-]*-([^-]*-?[^.]*?\.[^:]*):.*/\1/' -e 's/\.glb//')
 
@@ -135,8 +135,7 @@ for namePort in $bootstrap $brokers; do
         else
             # shellcheck disable=SC2059
             printf "$fmt" "FAIL" "$namePort"
-            # shellcheck disable=SC2059
-            printf "    unable to connect, firewall/security group? (received \"$connectivity\", expected \"$expectedConnectivity\")\n\n"
+            printf "    unable to connect, firewall/security group? (received \"%s\", expected \"%s\")\n\n" "$connectivity" "$expectedConnectivity"
         fi
     else
         # shellcheck disable=SC2059

--- a/aws-privatelink/debug-connectivity.sh
+++ b/aws-privatelink/debug-connectivity.sh
@@ -48,6 +48,11 @@ key=$3
 # yields              4ny6k.us-west-2.aws.confluent.cloud
 hz=$(echo "$bootstrap" | sed -E -e 's/^[^-]*-[^-]*-([^-]*-?[^.]*?\.[^:]*):.*/\1/' -e 's/\.glb//')
 
+if ! [[ $bootstrap =~ : ]]; then
+    echo "error: bootstrap missing port ($bootstrap, no :9092 for example)" 1>&2
+    exit 1
+fi
+
 declare -A zonemap
 declare -A endpointmap
 

--- a/aws-privatelink/debug-connectivity.sh
+++ b/aws-privatelink/debug-connectivity.sh
@@ -11,6 +11,7 @@
 #   % debug-connectivity.sh vpce-0123456789abcdef0 lkc-3gyjw-l63jl.us-west-2.aws.glb.confluent.cloud:9092 QVZ72AZWH4DRNOZT
 #   API Secret (paste hidden; press enter):
 #
+#   OK    https://lkc-3gyjw-l63jl.us-west-2.aws.glb.confluent.cloud
 #   OK    lkc-3gyjw-l63jl.us-west-2.aws.glb.confluent.cloud:9092
 #   OK    e-0cb9-usw2-az1-l63jl.us-west-2.aws.glb.confluent.cloud:9092
 #   OK    e-24ab-usw2-az3-l63jl.us-west-2.aws.glb.confluent.cloud:9092
@@ -31,6 +32,9 @@ openssl version 1>/dev/null 2>/dev/null
 
 aws 1>/dev/null 2>/dev/null
 [[ $? == 127 ]] && echo "warning: please install 'aws'"
+
+curl 1>/dev/null 2>/dev/null
+[[ $? == 127 ]] && echo "warning: please install 'curl'"
 
 if [[ $# != 3 ]]; then
     echo "usage: $0 <vpc-endpoint> <bootstrap> <api-key>" 1>&2
@@ -91,6 +95,30 @@ for name in $(aws ec2 describe-vpc-endpoints \
 done
 
 fmt="%-5s %s\n"
+
+#
+# verify https path is functional
+#
+
+# shellcheck disable=SC2001
+httpsname="https://$(echo "$bootstrap" | sed -e 's/:.*//')"
+httpsout=$(curl --silent --include "$httpsname")
+httpsexpected="HTTP/1.1 401 Unauthorized"
+httpsactual="$(echo "$httpsout" | grep HTTP/ | tr -d '\r')"
+# shellcheck disable=SC2181
+if [[ $? != 0 ]] || [[ "$httpsactual" != "$httpsexpected" ]]; then
+    # shellcheck disable=SC2059
+    printf "$fmt" "FAIL" "$httpsname"
+    printf "    unexpected output from https endpoint (received \"%s\", expected \"%s\")\n\n" "$httpsactual" "$httpsexpected"
+else
+    # shellcheck disable=SC2059
+    printf "$fmt" "OK" "$httpsname"
+fi
+
+#
+# verify kafka bootstrap/broker paths are functional
+#
+
 kcatout=$(kafkacat \
     -X security.protocol=SASL_SSL \
     -X "sasl.username=$key" \


### PR DESCRIPTION
Ensure simply forgetting the bootstrap port is more gracefully handled.

Ensure https path is also verified.

More gracefully handle kafkacat errors.