### PR TITLE
aws/debug-connectivity: support bsd sed

### DIFF
--- a/privatelink/aws/debug-connectivity.sh
+++ b/privatelink/aws/debug-connectivity.sh
@@ -50,7 +50,7 @@ bootstrap=$2
 key=$3
 #           lkc-py7g5-4ny6k.us-west-2.aws.glb.confluent.cloud:9092
 # yields              4ny6k.us-west-2.aws.confluent.cloud
-hz=$(echo "$bootstrap" | sed -E -e 's/^[^-]*-[^-]*-([^-]*-?[^.]*?\.[^:]*):.*/\1/' -e 's/\.glb//')
+hz=$(echo "$bootstrap" | sed -E -e 's/^[^-]*-[^-]*-([^-]*-?[^.]*\.[^:]*):.*/\1/' -e 's/\.glb//')
 
 if ! [[ $bootstrap =~ : ]]; then
     echo "error: bootstrap missing port ($bootstrap, no :9092 for example)" 1>&2


### PR DESCRIPTION
BSD sed doesn't support `*?`.  This shouldn't be required anyways.