### PR TITLE
Modify terraform script to support SZ

### DIFF
--- a/privatelink/aws/terraform/privatelink.tf
+++ b/privatelink/aws/terraform/privatelink.tf
@@ -97,6 +97,7 @@ resource "aws_route53_zone" "privatelink" {
 }
 
 resource "aws_route53_record" "privatelink" {
+  count = length(var.subnets_to_privatelink) == 1 ? 0 : 1
   zone_id = aws_route53_zone.privatelink.zone_id
   name = "*.${aws_route53_zone.privatelink.name}"
   type = "CNAME"
@@ -114,7 +115,7 @@ resource "aws_route53_record" "privatelink-zonal" {
   for_each = var.subnets_to_privatelink
 
   zone_id = aws_route53_zone.privatelink.zone_id
-  name = "*.${each.key}"
+  name = length(var.subnets_to_privatelink) == 1 ? "*" : "*.${each.key}"
   type = "CNAME"
   ttl  = "60"
   records = [


### PR DESCRIPTION
## Change

Change the terraform script so that when only one zone specified, only one CNAME record will be created by terraform
* `*.lokrp.us-west-2.aws.devel.cpdev.cloud` → `vpce-0e48a0845f62ddd94-hw1gfa2b-us-west-2c.vpce-svc-094f06233d39da7d1.us-west-2.vpce.amazonaws.com`

vs. 

Previously two records will be created
* `*.lokrp.us-west-2.aws.devel.cpdev.cloud` → `vpce-03f6dbf491c477b7c-n13unlo6.vpce-svc-094f06233d39da7d1.us-west-2.vpce.amazonaws.com`
* `*.usw2-az3.lokrp.us-west-2.aws.devel.cpdev.cloud` → `vpce-03f6dbf491c477b7c-n13unlo6-us-west-2c.vpce-svc-094f06233d39da7d1.us-west-2.vpce.amazonaws.com`


## Test
1. log into a dev machine
2. apply this modified terraform script
3. change Route53 records
