### PR TITLE
Add bootstrap prefix as Security Group suffix

### DIFF
--- a/privatelink/aws/terraform/privatelink.tf
+++ b/privatelink/aws/terraform/privatelink.tf
@@ -52,7 +52,7 @@ locals {
 }
 
 resource "aws_security_group" "privatelink" {
-  # Ensure SG uniqueness adding a suffix with cluster id and VPC id. This also helps identifying the resource.
+  # Ensure that SG is unique, so that this module can be used multiple times within a single VPC
   name = "ccloud-privatelink_${local.bootstrap_prefix}_${var.vpc_id}"
   description = "Confluent Cloud Private Link minimal security group for ${var.bootstrap} in ${var.vpc_id}"
   vpc_id = data.aws_vpc.privatelink.id

--- a/privatelink/aws/terraform/privatelink.tf
+++ b/privatelink/aws/terraform/privatelink.tf
@@ -52,6 +52,7 @@ locals {
 }
 
 resource "aws_security_group" "privatelink" {
+  # Ensure SG uniqueness adding a suffix with cluster id and VPC id. This also helps identifying the resource.
   name = "ccloud-privatelink_${local.bootstrap_prefix}_${var.vpc_id}"
   description = "Confluent Cloud Private Link minimal security group for ${var.bootstrap} in ${var.vpc_id}"
   vpc_id = data.aws_vpc.privatelink.id

--- a/privatelink/aws/terraform/privatelink.tf
+++ b/privatelink/aws/terraform/privatelink.tf
@@ -47,9 +47,17 @@ data "aws_availability_zone" "privatelink" {
   zone_id = each.key
 }
 
+locals {
+  bootstrap_prefix = split(".", var.bootstrap)[0]
+}
+
+resource "random_id" "server" {
+  byte_length = 8
+}
+
 resource "aws_security_group" "privatelink" {
-  name = "ccloud-privatelink"
-  description = "Confluent Cloud Private Link minimal security group"
+  name = "ccloud-privatelink_${bootstrap_prefix}_${random_id.id}"
+  description = "Confluent Cloud Private Link minimal security group for ${var.bootstrap}"
   vpc_id = data.aws_vpc.privatelink.id
 
   ingress {
@@ -72,6 +80,10 @@ resource "aws_security_group" "privatelink" {
     to_port = 9092
     protocol = "tcp"
     cidr_blocks = [data.aws_vpc.privatelink.cidr_block]
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 

--- a/privatelink/aws/terraform/privatelink.tf
+++ b/privatelink/aws/terraform/privatelink.tf
@@ -51,13 +51,9 @@ locals {
   bootstrap_prefix = split(".", var.bootstrap)[0]
 }
 
-resource "random_id" "server" {
-  byte_length = 8
-}
-
 resource "aws_security_group" "privatelink" {
-  name = "ccloud-privatelink_${bootstrap_prefix}_${random_id.id}"
-  description = "Confluent Cloud Private Link minimal security group for ${var.bootstrap}"
+  name = "ccloud-privatelink_${bootstrap_prefix}_${var.vpc_id}"
+  description = "Confluent Cloud Private Link minimal security group for ${var.bootstrap} in ${var.vpc_id}"
   vpc_id = data.aws_vpc.privatelink.id
 
   ingress {

--- a/privatelink/aws/terraform/privatelink.tf
+++ b/privatelink/aws/terraform/privatelink.tf
@@ -52,7 +52,7 @@ locals {
 }
 
 resource "aws_security_group" "privatelink" {
-  name = "ccloud-privatelink_${bootstrap_prefix}_${var.vpc_id}"
+  name = "ccloud-privatelink_${local.bootstrap_prefix}_${var.vpc_id}"
   description = "Confluent Cloud Private Link minimal security group for ${var.bootstrap} in ${var.vpc_id}"
   vpc_id = data.aws_vpc.privatelink.id
 


### PR DESCRIPTION
We might want to use this module in the same AWS account,
but we are creating one SG with a fixed name.

Here we use the privatelink endpoint prefix (eg. lkc-abcde-vwxyz)
as suffix for the SG name, and also add a random id,
so it is unique for each cluster and easy to identify.