### PR TITLE
Remove dependency of custom build

### DIFF
--- a/privatelink/azure/terraform/README.md
+++ b/privatelink/azure/terraform/README.md
@@ -9,24 +9,3 @@ After populating it, simply run terraform (https://www.terraform.io/):
     terraform apply
 
 The `privatelink_service_alias` is provided to you directly from Confluent.
-
-## Issues
-
-Currently depends on fixed behavior associated with these two upstream pull
-requests:
-
-- https://github.com/terraform-providers/terraform-provider-azurerm/pull/9793
-- https://github.com/terraform-providers/terraform-provider-azurerm/pull/9794
-
-A custom compiled binary is available here:
-
-- https://github.com/confluentinc/terraform-provider-azurerm/releases/tag/v2.39.0-confluent-fixed
-
-To use:
-
-```
-terraform init
-mv ~/Downloads/terraform-provider-azurerm .terraform/plugins/linux_amd64/terraform-provider-azurerm_v2.32.0_x5
-terraform init
-terraform apply
-```

--- a/privatelink/azure/terraform/privatelink.tf
+++ b/privatelink/azure/terraform/privatelink.tf
@@ -5,7 +5,7 @@ terraform {
 provider "azurerm" {
   features {
   }
-  version = ">= 2.55.0"
+  version = "~> 2.55.0"
 }
 
 

--- a/privatelink/azure/terraform/privatelink.tf
+++ b/privatelink/azure/terraform/privatelink.tf
@@ -5,7 +5,7 @@ terraform {
 provider "azurerm" {
   features {
   }
-  version = "= 2.32.0"
+  version = ">= 2.55.0"
 }
 
 
@@ -65,7 +65,7 @@ data "azurerm_subnet" "subnet" {
 locals {
   assert_no_network_policies_enabled = length([
     for _, subnet in data.azurerm_subnet.subnet:
-    true if subnet.enforce_private_link_endpoint_network_policies
+    true if !subnet.enforce_private_link_endpoint_network_policies
   ]) > 0 ? file("\n\nerror: private link endpoint network policies must be disabled https://docs.microsoft.com/en-us/azure/private-link/disable-private-endpoint-network-policy") : ""
 }
 
@@ -85,10 +85,10 @@ resource "azurerm_private_endpoint" "endpoint" {
   subnet_id = data.azurerm_subnet.subnet[each.key].id
 
   private_service_connection {
-    name                           = "confluent-${local.network_id}-${each.key}"
-    is_manual_connection           = true
-    private_connection_resource_id = each.value
-    request_message                = "PL"
+    name                              = "confluent-${local.network_id}-${each.key}"
+    is_manual_connection              = true
+    private_connection_resource_alias = each.value
+    request_message                   = "PL"
   }
 }
 


### PR DESCRIPTION
Change
---
After [this change](https://github.com/terraform-providers/terraform-provider-azurerm/pull/10779) of Azure provider in terraform has been merged and rolled out to `2.55.0`, we no longer need the custom build to support creating private link using private connection alias.

For the flip of `enforce_private_link_endpoint_network_policies`, see the discussion [here](https://github.com/terraform-providers/terraform-provider-azurerm/pull/9793).

Test
---
Create private link using this terraform from scratch.