### PR TITLE
Fix terraform version: 0.12.17 -> 0.13.7

### DIFF
--- a/privatelink/aws/terraform/privatelink.tf
+++ b/privatelink/aws/terraform/privatelink.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.17"
+  required_version = ">= 0.13.7"
 }
 
 provider "aws" {


### PR DESCRIPTION
### Issue
$ terraform plan
╷
│ Warning: Version constraints inside provider configuration blocks are deprecated
│
│   on privatelink.tf line 7, in provider "aws":
│    7:   version = "= 2.32.0"
│
│ Terraform 0.13 and earlier allowed provider version constraints inside the provider configuration block, but that is now deprecated and will be removed in a
│ future version of Terraform. To silence this warning, move the provider version constraint into the required_providers block.

### Fix
After upgrading terraform to 0.13.7, I successfully ran `terraform destroy` to destroy network resources
$ terraform destroy
...
Destroy complete! Resources: 7 destroyed.
$ terraform --version
Terraform v0.13.7
+ provider registry.terraform.io/-/aws v3.40.0
+ provider registry.terraform.io/hashicorp/aws v2.32.0

