### PR TITLE
Moved provider version constraints into a required_providers block

### DIFF
--- a/privatelink/aws/terraform/privatelink.tf
+++ b/privatelink/aws/terraform/privatelink.tf
@@ -1,10 +1,15 @@
 terraform {
   required_version = ">= 0.13.7"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "= 2.32.0"
+    }
+  }
 }
 
 provider "aws" {
   region  = var.region
-  version = "= 2.32.0"
 }
 
 

--- a/privatelink/azure/terraform/privatelink.tf
+++ b/privatelink/azure/terraform/privatelink.tf
@@ -1,13 +1,17 @@
 terraform {
   required_version = ">= 0.12.17"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 2.55.0"
+    }
+  }
 }
 
 provider "azurerm" {
   features {
   }
-  version = "~> 2.55.0"
 }
-
 
 variable "resource_group" {
   description = "Resource group of the VNET"


### PR DESCRIPTION
Resolves deprecation warnings e.g.:

```
│ Warning: Version constraints inside provider configuration blocks are deprecated
│
│   on privatelink.tf line 8, in provider "azurerm":
│    8:   version = "~> 2.55.0"
│
│ Terraform 0.13 and earlier allowed provider version constraints inside the provider configuration block, but that is now deprecated and will be removed in a future version of Terraform. To silence this warning, move the provider
│ version constraint into the required_providers block.
```