### PR TITLE
adapt to new kafka-rest endpoints

### DIFF
--- a/privatelink/aws/debug-connectivity.sh
+++ b/privatelink/aws/debug-connectivity.sh
@@ -103,7 +103,7 @@ fmt="%-5s %s\n"
 # shellcheck disable=SC2001
 httpsname="https://$(echo "$bootstrap" | sed -e 's/:.*//')"
 httpsout=$(curl --silent --include "$httpsname")
-httpsexpected="HTTP/1.1 401 Unauthorized"
+httpsexpected="HTTP/2 401 "
 httpsactual="$(echo "$httpsout" | grep HTTP/ | tr -d '\r')"
 # shellcheck disable=SC2181
 if [[ $? != 0 ]] || [[ "$httpsactual" != "$httpsexpected" ]]; then


### PR DESCRIPTION
adapted to the new kafka-rest endpoints using http/2.

```
FAIL  https://lkc-0nzg6-ld107.us-east-2.aws.glb.confluent.cloud

    unexpected output from https endpoint (received "HTTP/2 401 ", expected "HTTP/1.1 401 Unauthorized")

```