### PR TITLE
[TRAFFIC-2037] Fixing connectivity check for https path.

### DIFF
--- a/privatelink/aws/debug-connectivity.sh
+++ b/privatelink/aws/debug-connectivity.sh
@@ -115,6 +115,21 @@ else
     printf "$fmt" "OK" "$httpsname"
 fi
 
+# shellcheck disable=SC2001
+httpsname="https://$(echo "$bootstrap" | sed -e 's/:.*//;s/lkc-/lkaclkc-/')"
+httpsout=$(curl --silent --include "$httpsname")
+httpsexpected="HTTP/.* 401"
+httpsactual="$(echo "$httpsout" | grep HTTP/ | tr -d '\r')"
+# shellcheck disable=SC2181
+if [[ $? != 0 ]] || [[ ! "$httpsactual" =~ $httpsexpected ]]; then
+    # shellcheck disable=SC2059
+    printf "$fmt" "FAIL" "$httpsname"
+    printf "    unexpected output from https endpoint (received \"%s\", expected \"%s\")\n\n" "$httpsactual" "$httpsexpected"
+else
+    # shellcheck disable=SC2059
+    printf "$fmt" "OK" "$httpsname"
+fi
+
 #
 # verify kafka bootstrap/broker paths are functional
 #


### PR DESCRIPTION

Testing:

```
admin@ip-10-0-0-10:~/ccloud-connectivity/privatelink/aws$ ./debug-connectivity.sh vpce-0bbb907b7f7dc2dec lkc-3w6gx0-56xj7g.us-west-2.aws.glb.devel.cpdev.cloud:9092 5I646ZV5BW33SCMO
API Secret (paste hidden; press enter):

FAIL  https://lkc-3w6gx0-56xj7g.us-west-2.aws.glb.devel.cpdev.cloud
    unexpected output from https endpoint (received "", expected "HTTP/.* 401")

OK    https://lkaclkc-3w6gx0-56xj7g.us-west-2.aws.glb.devel.cpdev.cloud
```