### PR TITLE
Add TF config for automating the steps from Create a VPC Peering Connection to Confluent Cloud on AWS doc.

### DIFF
--- a/vpc-peering/aws/README.md
+++ b/vpc-peering/aws/README.md
@@ -1,0 +1,4 @@
+# vpc-peering/aws
+
+* The [terraform](./terraform) directory contains a method to setup an AWS
+  Peering with Confluent Cloud.

--- a/vpc-peering/aws/terraform/README.md
+++ b/vpc-peering/aws/terraform/README.md
@@ -1,0 +1,11 @@
+# vpc-peering/aws/terraform
+
+## Terraform tfvars
+Use the supplied `terraform.tfvars` file to supply required parameters to
+setup your VPC for Confluent Cloud Peering.
+
+## Run terraform
+After populating it, simply run terraform (https://www.terraform.io/):
+
+    terraform init
+    terraform apply

--- a/vpc-peering/aws/terraform/peering.tf
+++ b/vpc-peering/aws/terraform/peering.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_version = ">= 0.13.7"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "= 2.32.0"
+    }
+  }
+}
+
+# https://docs.confluent.io/cloud/current/networking/peering/aws-peering.html
+# Create a VPC Peering Connection to Confluent Cloud on AWS
+provider "aws" {
+  region = var.region
+}
+
+# Customer's side of the connection.
+data "aws_vpc_peering_connection" "accepter" {
+  vpc_id      = var.confluent_vpc_id
+  peer_vpc_id = var.customer_vpc_id
+}
+
+resource "aws_vpc_peering_connection_accepter" "peer" {
+  vpc_peering_connection_id = data.aws_vpc_peering_connection.accepter.id
+  auto_accept               = true
+}
+
+# Find the routing table
+data "aws_route_tables" "rts" {
+  vpc_id = var.customer_vpc_id
+}
+
+resource "aws_route" "r" {
+  for_each                  = toset(data.aws_route_tables.rts.ids)
+  route_table_id            = each.key
+  destination_cidr_block    = var.confluent_cidr
+  vpc_peering_connection_id = data.aws_vpc_peering_connection.accepter.id
+
+  depends_on = [
+    aws_vpc_peering_connection_accepter.peer
+  ]
+}

--- a/vpc-peering/aws/terraform/terraform.tfvars
+++ b/vpc-peering/aws/terraform/terraform.tfvars
@@ -1,0 +1,18 @@
+# The region of the AWS peer VPC.
+region = "us-east-2"
+
+# The AWS VPC ID of the peer VPC that you're peering with Confluent Cloud.
+# You can find your AWS VPC ID here (https://console.aws.amazon.com/vpc/) under Your VPCs section of the AWS Management Console. Must start with `vpc-`.
+customer_vpc_id = "vpc-0b9bba0e776228180"
+
+# "The Confluent's VPC ID (provided by Confluent under Network Management tab)"
+confluent_vpc_id = "vpc-abcdef0123456789a"
+
+# "The Confluent's VPC's CIDR (provided by Confluent under Network Management tab)"
+confluent_cidr = "10.10.0.0/16"
+
+# Add credentials and other settings to $HOME/.aws/config
+# for AWS TF Provider to work: https://registry.terraform.io/providers/hashicorp/aws/latest/docs#shared-configuration-and-credentials-files
+
+# Requirements of VPC Peering on AWS
+# https://docs.confluent.io/cloud/current/networking/peering/aws-peering.html#vpc-peering-on-aws

--- a/vpc-peering/aws/terraform/variables.tf
+++ b/vpc-peering/aws/terraform/variables.tf
@@ -1,0 +1,19 @@
+variable "region" {
+  description = "The AWS Region of the existing VPC"
+  type        = string
+}
+
+variable "customer_vpc_id" {
+  description = "The customer's VPC ID to private link to Confluent Cloud"
+  type        = string
+}
+
+variable "confluent_vpc_id" {
+  description = "The Confluent's VPC ID (provided by Confluent under Network Management tab)"
+  type        = string
+}
+
+variable "confluent_cidr" {
+  description = "The Confluent's VPC's CIDR (provided by Confluent under Network Management tab)"
+  type        = string
+}


### PR DESCRIPTION
### What
Add a TF config for automating the steps from [Create a VPC Peering Connection to Confluent Cloud on AWS](https://docs.confluent.io/cloud/current/networking/peering/aws-peering.html) doc.

### Tests
```
➜  terraform git:(add-aws-vpc-peering) ✗ terraform init    

Initializing the backend...

Initializing provider plugins...
- Finding hashicorp/aws versions matching "2.32.0"...
- Installing hashicorp/aws v2.32.0...
- Installed hashicorp/aws v2.32.0 (signed by HashiCorp)

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
➜  terraform git:(add-aws-vpc-peering) ✗ terraform validate
Success! The configuration is valid.

```