### PR TITLE
Fixes the instructions for finding the VPC Endpoint service name

### DIFF
--- a/privatelink/aws/terraform/README.md
+++ b/privatelink/aws/terraform/README.md
@@ -6,8 +6,8 @@ setup your VPC for Confluent Cloud Private Link.
 
 * region: vpc region
 * vpc_id: the vpc id that you want to connect to Confluent Cloud Cluster.
-* privatelink_service_name, a.k.a VPC Endpoint service: provided by Confluent Cloud UI. Cluster settings ->
-  Networking tab
+* privatelink_service_name, a.k.a VPC Endpoint service: provided by Confluent Cloud UI. Cluster Overview ->
+  Networking tab -> Details
 * bootstrap: provided by Confluent Cloud UI. Cluster settings -> General tab
 * subnets_to_privatelink: you can find subnets to private link mapping
   information from your AWS console -> VPC -> subnets


### PR DESCRIPTION
Just a quick doc update. Looks like the tab for networking moved from cluster settings to its own tab under cluster overview