### PR TITLE
TRAFFIC-3489: check aws-cli version in debug-connectivity.sh

### DIFF
--- a/privatelink/aws/debug-connectivity.sh
+++ b/privatelink/aws/debug-connectivity.sh
@@ -34,6 +34,9 @@ openssl version 1>/dev/null 2>/dev/null
 aws 1>/dev/null 2>/dev/null
 [[ $? == 127 ]] && echo "warning: please install 'aws'"
 
+aws_ver=$(aws --version | cut -d' ' -f 1 | cut -d/ -f 2 | cut -d. -f 1)
+[[ $aws_ver -lt 2 ]] && echo "warning: please install 'aws' v2"
+
 curl 1>/dev/null 2>/dev/null
 [[ $? == 127 ]] && echo "warning: please install 'curl'"
 


### PR DESCRIPTION
Following scripts in debug-connectivity.sh requires aws-cli v2 to work 

```
for nameId in $(aws ec2 describe-availability-zones \
    --query 'AvailabilityZones[*].[ZoneName, ZoneId]' \
    --output text); do
    name=$(echo "$nameId" | awk '{print $1}')
    id=$(echo "$nameId" | awk '{print $2}')
    zonemap[$id]=$name
done
```

classic aws-cli does not support returning of ZoneId, this can cause debug-connectivity.sh to throw confusing error messages.

Example output of aws v1 execution:

```
aws ec2 describe-availability-zones --query 'AvailabilityZones[*].[ZoneName, ZoneId]'     --output text
us-west-2a	None
us-west-2b	None
us-west-2c	None
us-west-2d	None
```


Example output of aws v2 execution:

```
aws ec2 describe-availability-zones \
    --query 'AvailabilityZones[*].[ZoneName, ZoneId]' \
    --output text
us-west-2a      usw2-az1
us-west-2b      usw2-az2
us-west-2c      usw2-az3
us-west-2d      usw2-az4
```