### PR TITLE
Bump aws provider version to unblock atlantis migration

### DIFF
--- a/privatelink/aws/terraform/privatelink.tf
+++ b/privatelink/aws/terraform/privatelink.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "= 2.32.0"
+      version = "~> 4.31"
     }
   }
 }


### PR DESCRIPTION
This version of the aws provider is too old and cannot correctly assume role using web identity. This blocks users from onboarding to atlantis.