### PR TITLE
Remove provider configuration from module.

### DIFF
--- a/privatelink/aws/terraform/privatelink.tf
+++ b/privatelink/aws/terraform/privatelink.tf
@@ -8,11 +8,6 @@ terraform {
   }
 }
 
-provider "aws" {
-  region  = var.region
-}
-
-
 variable "region" {
   description = "The AWS Region of the existing VPC"
   type = string


### PR DESCRIPTION
Defining providers in modules isn't supported in newer versions of terraform.