### PR TITLE
Clusters deployed with private dns enabled do not have `glb` in the bootstrap url

### DIFF
--- a/privatelink/aws/terraform/privatelink.tf
+++ b/privatelink/aws/terraform/privatelink.tf
@@ -39,7 +39,7 @@ variable "subnets_to_privatelink" {
 }
 
 locals {
-  hosted_zone = replace(regex("^[^.]+-([0-9a-zA-Z]+[.].*):[0-9]+$", var.bootstrap)[0], "glb.", "")
+  hosted_zone = length(regexall(".glb", var.bootstrap)) > 0 ? regex("^[^.]+-([0-9a-zA-Z]+[.].*):[0-9]+$", var.bootstrap)[0] : regex("[.]([0-9a-zA-Z]+[.].*):[0-9]+$", var.bootstrap)[0]
 }
 
 

--- a/privatelink/aws/terraform/privatelink.tf
+++ b/privatelink/aws/terraform/privatelink.tf
@@ -39,7 +39,7 @@ variable "subnets_to_privatelink" {
 }
 
 locals {
-  hosted_zone = length(regexall(".glb", var.bootstrap)) > 0 ? regex("^[^.]+-([0-9a-zA-Z]+[.].*):[0-9]+$", var.bootstrap)[0] : regex("[.]([0-9a-zA-Z]+[.].*):[0-9]+$", var.bootstrap)[0]
+  hosted_zone = length(regexall(".glb", var.bootstrap)) > 0 ? replace(regex("^[^.]+-([0-9a-zA-Z]+[.].*):[0-9]+$", var.bootstrap)[0], "glb.", "") : regex("[.]([0-9a-zA-Z]+[.].*):[0-9]+$", var.bootstrap)[0]
 }
 
 


### PR DESCRIPTION

The regex to retrieve the zone id needs to be adjusted a bit for private dns enabled bootstrap URLs.

For now, focusing on aws changes.  We will make the changes to Azure and GCP in the next round of changes.