### PR TITLE
Clusters deployed with private dns enabled do not have glb in the boottstrap url

### DIFF
--- a/privatelink/gcp/terraform/privatelink.tf
+++ b/privatelink/gcp/terraform/privatelink.tf
@@ -52,7 +52,7 @@ variable "psc_service_attachments_by_zone" {
 }
 
 locals {
-  hosted_zone = replace(regex("^[^.]+-([0-9a-zA-Z]+[.].*):[0-9]+$", var.bootstrap)[0], "glb.", "")
+  hosted_zone = length(regexall(".glb", var.bootstrap)) > 0 ? replace(regex("^[^.]+-([0-9a-zA-Z]+[.].*):[0-9]+$", var.bootstrap)[0], "glb.", "") : regex("[.]([0-9a-zA-Z]+[.].*):[0-9]+$", var.bootstrap)[0]
   network_id  = regex("^([^.]+)[.].*", local.hosted_zone)[0]
 }
 


### PR DESCRIPTION
This is related to the new private dns capability which is now EA for aws.  Here is the related PR for aws related changes and the same changes should be applicable for both gcp and azure.  We tested these once with GCP E2E Private link customer workflow and it seems to be working fine.

https://github.com/confluentinc/ccloud-connectivity/pull/36 - for AWS. 