### PR TITLE
remove assert_no_network_policies_enabled

### DIFF
--- a/privatelink/azure/terraform/privatelink.tf
+++ b/privatelink/azure/terraform/privatelink.tf
@@ -67,10 +67,6 @@ data "azurerm_subnet" "subnet" {
 }
 
 locals {
-  assert_no_network_policies_enabled = length([
-    for _, subnet in data.azurerm_subnet.subnet:
-    true if !subnet.enforce_private_link_endpoint_network_policies
-  ]) > 0 ? file("\n\nerror: private link endpoint network policies must be disabled https://docs.microsoft.com/en-us/azure/private-link/disable-private-endpoint-network-policy") : ""
 }
 
 resource "azurerm_private_dns_zone" "hz" {

--- a/privatelink/azure/terraform/privatelink.tf
+++ b/privatelink/azure/terraform/privatelink.tf
@@ -66,9 +66,6 @@ data "azurerm_subnet" "subnet" {
   resource_group_name  = data.azurerm_resource_group.rg.name
 }
 
-locals {
-}
-
 resource "azurerm_private_dns_zone" "hz" {
   resource_group_name = data.azurerm_resource_group.rg.name
 


### PR DESCRIPTION
WHAT
-------

Confluent Cloud does not require disable private endpoint network policy when creating private link on azure. 

TEST
------

* Pending @anjvenkat . Will test using her azure PL tests to ensure both disable and enable the policy works