### PR TITLE
Clusters deployed with private dns enabled do not have glb in the boo…

### DIFF
--- a/privatelink/azure/terraform/privatelink.tf
+++ b/privatelink/azure/terraform/privatelink.tf
@@ -44,7 +44,7 @@ variable "subnet_name_by_zone" {
 }
 
 locals {
-  hosted_zone = replace(regex("^[^.]+-([0-9a-zA-Z]+[.].*):[0-9]+$", var.bootstrap)[0], "glb.", "")
+  hosted_zone = length(regexall(".glb", var.bootstrap)) > 0 ? replace(regex("^[^.]+-([0-9a-zA-Z]+[.].*):[0-9]+$", var.bootstrap)[0], "glb.", "") : regex("[.]([0-9a-zA-Z]+[.].*):[0-9]+$", var.bootstrap)[0]
   network_id = regex("^([^.]+)[.].*", local.hosted_zone)[0]
 }
 


### PR DESCRIPTION
…tstrap url

adding changes for azure, similar to https://github.com/confluentinc/ccloud-connectivity/pull/36 and https://github.com/confluentinc/ccloud-connectivity/pull/37