### PR TITLE
Simplify TF configuration for AWS Peering.

### DIFF
--- a/vpc-peering/aws/terraform/peering.tf
+++ b/vpc-peering/aws/terraform/peering.tf
@@ -25,14 +25,12 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
   auto_accept               = true
 }
 
-# Find the routing table
-data "aws_route_tables" "rts" {
-  vpc_id = var.customer_vpc_id
+data "aws_vpc" "customer_vpc" {
+  id = var.customer_vpc_id
 }
 
 resource "aws_route" "r" {
-  for_each                  = toset(data.aws_route_tables.rts.ids)
-  route_table_id            = each.key
+  route_table_id            = data.aws_vpc.customer_vpc.main_route_table_id
   destination_cidr_block    = var.confluent_cidr
   vpc_peering_connection_id = data.aws_vpc_peering_connection.accepter.id
 


### PR DESCRIPTION
### What
This PR simplifies TF config by removing an unnecessary `for_each` block.

Newly created VPC has only one route table - [main route table](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html#main-route-table) and we may not need to use any data sources to get its ID. The main table has only local route, nothing else.

> Main route table—The route table that automatically comes with your VPC. It controls the routing for all subnets that are not explicitly associated with any other route table.

### References
* https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc#main_route_table_id