### PR TITLE
Add timeouts to curl calls in `debug-connectivity.sh`

### DIFF
--- a/privatelink/aws/debug-connectivity.sh
+++ b/privatelink/aws/debug-connectivity.sh
@@ -105,7 +105,7 @@ fmt="%-5s %s\n"
 
 # shellcheck disable=SC2001
 httpsname="https://$(echo "$bootstrap" | sed -e 's/:.*//')/kafka/v3/clusters/lkc-test"
-httpsout=$(curl --silent --include --connect-timeout 5 "$httpsname")
+httpsout=$(curl --silent --include --connect-timeout 15 "$httpsname")
 httpsexpected="HTTP/.* 401"
 httpsactual="$(echo "$httpsout" | grep HTTP/ | tr -d '\r')"
 # shellcheck disable=SC2181

--- a/privatelink/aws/debug-connectivity.sh
+++ b/privatelink/aws/debug-connectivity.sh
@@ -105,7 +105,7 @@ fmt="%-5s %s\n"
 
 # shellcheck disable=SC2001
 httpsname="https://$(echo "$bootstrap" | sed -e 's/:.*//')/kafka/v3/clusters/lkc-test"
-httpsout=$(curl --silent --include --connect-timeout 15 "$httpsname")
+httpsout=$(curl --silent --include --max-time 15 "$httpsname")
 httpsexpected="HTTP/.* 401"
 httpsactual="$(echo "$httpsout" | grep HTTP/ | tr -d '\r')"
 # shellcheck disable=SC2181

--- a/privatelink/aws/debug-connectivity.sh
+++ b/privatelink/aws/debug-connectivity.sh
@@ -105,7 +105,7 @@ fmt="%-5s %s\n"
 
 # shellcheck disable=SC2001
 httpsname="https://$(echo "$bootstrap" | sed -e 's/:.*//')/kafka/v3/clusters/lkc-test"
-httpsout=$(curl --silent --include "$httpsname")
+httpsout=$(curl --silent --include --connect-timeout 5 "$httpsname")
 httpsexpected="HTTP/.* 401"
 httpsactual="$(echo "$httpsout" | grep HTTP/ | tr -d '\r')"
 # shellcheck disable=SC2181

--- a/privatelink/azure/debug-connectivity.sh
+++ b/privatelink/azure/debug-connectivity.sh
@@ -103,7 +103,7 @@ fmt="%-5s %s\n"
 
 # shellcheck disable=SC2001
 httpsname="https://$(echo "$bootstrap" | sed -e 's/:.*//')/kafka/v3/clusters/lkc-test"
-httpsout=$(curl --silent --include --connect-timeout 5 "$httpsname")
+httpsout=$(curl --silent --include --connect-timeout 15 "$httpsname")
 httpsexpected="HTTP/1.1 401 Unauthorized"
 httpsactual="$(echo "$httpsout" | grep HTTP/ | tr -d '\r')"
 # shellcheck disable=SC2181

--- a/privatelink/azure/debug-connectivity.sh
+++ b/privatelink/azure/debug-connectivity.sh
@@ -103,7 +103,7 @@ fmt="%-5s %s\n"
 
 # shellcheck disable=SC2001
 httpsname="https://$(echo "$bootstrap" | sed -e 's/:.*//')/kafka/v3/clusters/lkc-test"
-httpsout=$(curl --silent --include --connect-timeout 15 "$httpsname")
+httpsout=$(curl --silent --include --max-time 15 "$httpsname")
 httpsexpected="HTTP/1.1 401 Unauthorized"
 httpsactual="$(echo "$httpsout" | grep HTTP/ | tr -d '\r')"
 # shellcheck disable=SC2181

--- a/privatelink/azure/debug-connectivity.sh
+++ b/privatelink/azure/debug-connectivity.sh
@@ -103,7 +103,7 @@ fmt="%-5s %s\n"
 
 # shellcheck disable=SC2001
 httpsname="https://$(echo "$bootstrap" | sed -e 's/:.*//')/kafka/v3/clusters/lkc-test"
-httpsout=$(curl --silent --include "$httpsname")
+httpsout=$(curl --silent --include --connect-timeout 5 "$httpsname")
 httpsexpected="HTTP/1.1 401 Unauthorized"
 httpsactual="$(echo "$httpsout" | grep HTTP/ | tr -d '\r')"
 # shellcheck disable=SC2181

--- a/privatelink/gcp/debug-connectivity.sh
+++ b/privatelink/gcp/debug-connectivity.sh
@@ -110,7 +110,7 @@ fmt="%-5s %s\n"
 
 # shellcheck disable=SC2001
 httpsname="https://$(echo "$bootstrap" | sed -e 's/:.*//')/kafka/v3/clusters/lkc-test"
-httpsout=$(curl --silent --include "$httpsname")
+httpsout=$(curl --silent --include --connect-timeout 5 "$httpsname")
 httpsexpected="HTTP/1.1 401 Unauthorized"
 httpsactual="$(echo "$httpsout" | grep HTTP/ | tr -d '\r')"
 # shellcheck disable=SC2181

--- a/privatelink/gcp/debug-connectivity.sh
+++ b/privatelink/gcp/debug-connectivity.sh
@@ -110,7 +110,7 @@ fmt="%-5s %s\n"
 
 # shellcheck disable=SC2001
 httpsname="https://$(echo "$bootstrap" | sed -e 's/:.*//')/kafka/v3/clusters/lkc-test"
-httpsout=$(curl --silent --include --connect-timeout 15 "$httpsname")
+httpsout=$(curl --silent --include --max-time 15 "$httpsname")
 httpsexpected="HTTP/1.1 401 Unauthorized"
 httpsactual="$(echo "$httpsout" | grep HTTP/ | tr -d '\r')"
 # shellcheck disable=SC2181

--- a/privatelink/gcp/debug-connectivity.sh
+++ b/privatelink/gcp/debug-connectivity.sh
@@ -110,7 +110,7 @@ fmt="%-5s %s\n"
 
 # shellcheck disable=SC2001
 httpsname="https://$(echo "$bootstrap" | sed -e 's/:.*//')/kafka/v3/clusters/lkc-test"
-httpsout=$(curl --silent --include --connect-timeout 5 "$httpsname")
+httpsout=$(curl --silent --include --connect-timeout 15 "$httpsname")
 httpsexpected="HTTP/1.1 401 Unauthorized"
 httpsactual="$(echo "$httpsout" | grep HTTP/ | tr -d '\r')"
 # shellcheck disable=SC2181


### PR DESCRIPTION
`curl` command can hang indefinitely when setup is incorrect. Add a timeout to prevent entire script from hanging. 15 seconds should be large enough.

Known scenarios where this can happen:

- AWS PrivateLink with incorrect inbound security rules on the VPC endpoint.

Add to all 3 clouds for consistency.