### PR TITLE
[TRAFFIC-11025] Fix parsing of AZ out of bootstrap and broker URLs for AWS PrivateLink clusters

### DIFF
--- a/privatelink/aws/debug-connectivity.sh
+++ b/privatelink/aws/debug-connectivity.sh
@@ -147,7 +147,16 @@ for namePort in $bootstrap $brokers; do
         zoneId="rr"
         expectedIPs=${endpointmap[rr]}
     else
-        zoneId=$(echo "$namePort" | sed -E -e 's/\..*/./' -e 's/^(lkc-[^-][^-]*|e)-[^-][^-]*-([^.][^.]*)-[^-][^-]*$/\2/')
+        # if namePort does not contain "glb" as the third domain (from top),
+        # fuse bottom three domains by replacing two dots with dashes to
+        # determine normalizedNamePort.
+        if [[ $(echo "$namePort" | awk -F. '{print $(NF-2)}') == "glb" ]]; then
+          normalizedNamePort=${nameport}
+        else
+          normalizedNamePort=$(echo "$namePort" | sed -E -e 's/\./-/' -e 's/\./-/')
+        fi
+
+        zoneId=$(echo "$normalizedNamePort" | sed -E -e 's/\..*/./' -e 's/^(lkc-[^-][^-]*|e)-[^-][^-]*-([^.][^.]*)-[^-][^-]*$/\2/')
         if [[ -z $zoneId ]]; then
             echo "error: unable to find zone id from broker name"
             exit 1


### PR DESCRIPTION
- For non-glb urls that separate lkc, broker octets, and AZ with dots, normalize them first by replacing bottom two dots with dashes before extracting AZ out of them