### PR TITLE
MINOR: use zone name instead of zone id to query the aws availability…

### DIFF
--- a/privatelink/aws/terraform/privatelink.tf
+++ b/privatelink/aws/terraform/privatelink.tf
@@ -44,7 +44,7 @@ data "aws_vpc" "privatelink" {
 
 data "aws_availability_zone" "privatelink" {
   for_each = var.subnets_to_privatelink
-  zone_id = each.key
+  name = each.key
 }
 
 locals {

--- a/privatelink/aws/terraform/terraform.tfvars
+++ b/privatelink/aws/terraform/terraform.tfvars
@@ -3,7 +3,7 @@ vpc_id = "vpc-0123456789abcdef0"
 privatelink_service_name = "com.amazonaws.vpce.us-east-1.vpce-svc-0123456789abcdef0"
 bootstrap = "lkc-abcde-vwxyz.us-east-1.aws.glb.confluent.cloud:9092"
 subnets_to_privatelink = {
-  "use1-az1" = "subnet-0123456789abcdef0",
-  "use1-az2" = "subnet-0123456789abcdef1",
-  "use1-az3" = "subnet-0123456789abcdef2",
+  "us-east-2a" = "subnet-0123456789abcdef0",
+  "us-east-2b" = "subnet-0123456789abcdef1",
+  "us-east-2c" = "subnet-0123456789abcdef2",
 }


### PR DESCRIPTION
using the zone id failed when I tried to retrieve the AZ, updated it to use the zone name succeeded.

we should use Name instead of ID for retrieving the AZ in TF
refer: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zone