### PR TITLE
Fallback to kcat if kafkacat is not available in debug-connectivity.sh for all cloud providers

### DIFF
--- a/privatelink/aws/debug-connectivity.sh
+++ b/privatelink/aws/debug-connectivity.sh
@@ -21,8 +21,15 @@
 #   OK    e-0ebc-usw2-az1-l63jl.us-west-2.aws.glb.confluent.cloud:9092
 #
 
-kafkacat 1> /dev/null 2>/dev/null
-[[ $? == 127 ]] && echo "warning: please install 'kafkacat'"
+# Check for kafkacat or kcat, prefer kcat if available
+KAFKACAT_BIN=""
+if which kcat >/dev/null 2>&1; then
+    KAFKACAT_BIN="kcat"
+elif which kafkacat >/dev/null 2>&1; then
+    KAFKACAT_BIN="kafkacat"
+else
+    echo "warning: please install 'kcat' or 'kafkacat'"
+fi
 
 dig 1>/dev/null 2>/dev/null
 [[ $? == 127 ]] && echo "warning: please install 'dig'"
@@ -122,7 +129,7 @@ fi
 # verify kafka bootstrap/broker paths are functional
 #
 
-kcatout=$(kafkacat \
+kcatout=$($KAFKACAT_BIN \
     -X security.protocol=SASL_SSL \
     -X "sasl.username=$key" \
     -X "sasl.password=$secret" \
@@ -134,7 +141,7 @@ kcatrc=$?
 brokers=$(echo "$kcatout" | grep ' at ' | sed -e 's/.* at //' -e 's/ .*//' | tr -d '\r')
 
 if (( kcatrc != 0 )); then
-    echo "error: kafkacat exited non-zero $kcatrc" 1>&2
+    echo "error: $KAFKACAT_BIN exited non-zero $kcatrc" 1>&2
     echo ""
     echo "$kcatout"
     exit 1

--- a/privatelink/azure/debug-connectivity.sh
+++ b/privatelink/azure/debug-connectivity.sh
@@ -20,8 +20,15 @@
 #   OK    e-0014-az3-4kxnm.centralus.azure.glb.devel.cpdev.cloud:9092
 #   OK    e-0012-az1-4kxnm.centralus.azure.glb.devel.cpdev.cloud:9092
 
-kafkacat 1> /dev/null 2>/dev/null
-[[ $? == 127 ]] && echo "warning: please install 'kafkacat'"
+# Check for kafkacat or kcat, prefer kcat if available
+KAFKACAT_BIN=""
+if which kcat >/dev/null 2>&1; then
+    KAFKACAT_BIN="kcat"
+elif which kafkacat >/dev/null 2>&1; then
+    KAFKACAT_BIN="kafkacat"
+else
+    echo "warning: please install 'kcat' or 'kafkacat'"
+fi
 
 dig 1>/dev/null 2>/dev/null
 [[ $? == 127 ]] && echo "warning: please install 'dig'"
@@ -120,7 +127,7 @@ fi
 # verify kafka bootstrap/broker paths are functional
 #
 
-kcatout=$(kafkacat \
+kcatout=$($KAFKACAT_BIN \
     -X security.protocol=SASL_SSL \
     -X "sasl.username=$key" \
     -X "sasl.password=$secret" \
@@ -132,7 +139,7 @@ kcatrc=$?
 brokers=$(echo "$kcatout" | grep ' at ' | sed -e 's/.* at //' -e 's/ .*//' | tr -d '\r')
 
 if (( kcatrc != 0 )); then
-    echo "error: kafkacat exited non-zero $kcatrc" 1>&2
+    echo "error: $KAFKACAT_BIN exited non-zero $kcatrc" 1>&2
     echo ""
     echo "$kcatout"
     exit 1

--- a/privatelink/gcp/debug-connectivity.sh
+++ b/privatelink/gcp/debug-connectivity.sh
@@ -37,8 +37,15 @@ function parse_region_from_service_attachment_uri() {
     echo "$1" | awk -F/regions/ '{print $NF}' | awk -F/ '{print $1}'
 }
 
-kafkacat 1> /dev/null 2>/dev/null
-[[ $? == 127 ]] && echo "warning: please install 'kafkacat'"
+# Check for kafkacat or kcat, prefer kcat if available
+KAFKACAT_BIN=""
+if which kcat >/dev/null 2>&1; then
+    KAFKACAT_BIN="kcat"
+elif which kafkacat >/dev/null 2>&1; then
+    KAFKACAT_BIN="kafkacat"
+else
+    echo "warning: please install 'kcat' or 'kafkacat'"
+fi
 
 dig 1>/dev/null 2>/dev/null
 [[ $? == 127 ]] && echo "warning: please install 'dig'"
@@ -124,9 +131,10 @@ else
 fi
 
 #
+
 # verify kafka bootstrap/broker paths are functional
 #
-kcatout=$(kafkacat \
+kcatout=$($KAFKACAT_BIN \
     -X security.protocol=SASL_SSL \
     -X "sasl.username=$key" \
     -X "sasl.password=$secret" \
@@ -138,7 +146,7 @@ kcatrc=$?
 brokers=$(echo "$kcatout" | grep ' at ' | sed -e 's/.* at //' -e 's/ .*//' | tr -d '\r')
 
 if (( kcatrc != 0 )); then
-    echo "error: kafkacat exited non-zero $kcatrc" 1>&2
+    echo "error: $KAFKACAT_BIN exited non-zero $kcatrc" 1>&2
     echo ""
     echo "$kcatout"
     exit 1


### PR DESCRIPTION
Since [kafkcat has been renamed to kcat](https://docs.confluent.io/platform/current/tools/kafkacat-usage.html), we should fallback to kcat if kafkacat is not available in debug-connectivity.sh for all cloud providers.

Example usage of `kafkacat` on Ubuntu22.04 systems:

```
$ cat /etc/os-release
PRETTY_NAME="Ubuntu 22.04.5 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.5 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy

$ kafkacat -V
kafkacat - Apache Kafka producer and consumer tool
https://github.com/edenhill/kafkacat
Copyright (c) 2014-2019, Magnus Edenhill
Version 1.6.0 (JSON, Transactions, librdkafka 1.8.0 builtin.features=gzip,snappy,ssl,sasl,regex,lz4,sasl_gssapi,sasl_plain,sasl_scram,plugins,zstd,sasl_oauthbearer)
```

Example usage of `kcat` on OSX systems:

```
$ sw_vers
ProductName:		macOS
ProductVersion:		15.6.1
BuildVersion:		24G90

$ which kcat
/opt/homebrew/bin/kcat

$ /opt/homebrew/bin/kcat -V
kcat - Apache Kafka producer and consumer tool
https://github.com/edenhill/kcat
Copyright (c) 2014-2021, Magnus Edenhill
Version 1.7.0 (JSON, Avro, Transactions, IncrementalAssign, librdkafka 2.8.0 builtin.features=gzip,snappy,ssl,sasl,regex,lz4,sasl_gssapi,sasl_plain,sasl_scram,plugins,zstd,sasl_oauthbearer,http,oidc)
```