### PR TITLE
Replace AZ name with AZ ID for PrivateLink Route 53 zonal DNS records

### DIFF
--- a/privatelink/aws/terraform/privatelink.tf
+++ b/privatelink/aws/terraform/privatelink.tf
@@ -132,7 +132,8 @@ resource "aws_route53_record" "privatelink-zonal" {
   for_each = var.subnets_to_privatelink
 
   zone_id = aws_route53_zone.privatelink.zone_id
-  name    = length(var.subnets_to_privatelink) == 1 ? "*" : "*.${each.key}"
+  name = length(var.subnets_to_privatelink) == 1 ? "*" :
+    "*.${data.aws_availability_zone.privatelink[each.key].zone_id}"
   type    = "CNAME"
   ttl     = "60"
   records = [

--- a/privatelink/aws/terraform/privatelink.tf
+++ b/privatelink/aws/terraform/privatelink.tf
@@ -132,8 +132,7 @@ resource "aws_route53_record" "privatelink-zonal" {
   for_each = var.subnets_to_privatelink
 
   zone_id = aws_route53_zone.privatelink.zone_id
-  name = length(var.subnets_to_privatelink) == 1 ? "*" :
-    "*.${data.aws_availability_zone.privatelink[each.key].zone_id}"
+  name    = length(var.subnets_to_privatelink) == 1 ? "*" : "*.${data.aws_availability_zone.privatelink[each.key].zone_id}"
   type    = "CNAME"
   ttl     = "60"
   records = [


### PR DESCRIPTION
This change updates the Route 53 record naming logic to use AZ IDs instead of AZ names when creating zonal wildcard records

During testing with a multi-AZ cluster, I found clients could not connect to brokers outside their own AZ because DNS records were named as *.us-west-2a…, while broker endpoints use AZ IDs e.g. *.usw2-az1… This mismatch caused DNS lookups to fall back to the regional endpoint, breaking cross-AZ connectivity. Note, the change [here](https://github.com/confluentinc/ccloud-connectivity/commit/90aff36f053197262a7ca9bb244354cf669e64c0) switched it from AZ ID to AZ name in the variables, but it seems the code here wasn't updated to use AZ ID